### PR TITLE
Keepalive DB tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,8 @@ gem 'padrino', '0.12.0'
 
 gem 'httparty'
 
-gem 'clockwork'
+# gem 'clockwork', '~> 0.7.3'
+gem 'clockwork', :github => 'robisenberg/clockwork', :ref => '7f9a6b1e0fe9a1de147e43985790a7d10e4d1216'
 
 gem 'foreman'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git://github.com/robisenberg/clockwork.git
+  revision: 7f9a6b1e0fe9a1de147e43985790a7d10e4d1216
+  ref: 7f9a6b1e0fe9a1de147e43985790a7d10e4d1216
+  specs:
+    clockwork (0.7.3)
+      activesupport
+      tzinfo
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -20,8 +29,6 @@ GEM
     atomic (1.1.15)
     bcrypt-ruby (3.1.2)
     builder (3.1.4)
-    clockwork (0.5.0)
-      tzinfo (~> 0.3.35)
     diff-lcs (1.2.5)
     dotenv (0.9.0)
     erubis (2.7.0)
@@ -118,7 +125,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (>= 3.1)
   bcrypt-ruby
-  clockwork
+  clockwork!
   erubis (~> 2.7.0)
   foreman
   httparty

--- a/admin/views/sites/_form.erb
+++ b/admin/views/sites/_form.erb
@@ -11,7 +11,7 @@
   <%= f.label :interval, :class => 'control-label' %>
   <div class='controls'>
     <%= f.text_field :interval, :class => 'form-control input-xlarge input-with-feedback' %>
-    <span class='help-inline'><%= error ? f.error_message_on(:interval) : "How long between pings." %></span>
+    <span class='help-inline'><%= error ? f.error_message_on(:interval) : "Number of seconds between pings." %></span>
   </div>
 </fieldset>
 <% error = @site.errors.include?(:ping_at) %>
@@ -19,9 +19,15 @@
   <%= f.label :ping_at, :class => 'control-label' %>
   <div class='controls'>
     <%= f.text_field :ping_at, :class => 'form-control input-xlarge input-with-feedback' %>
-    <span class='help-inline'><%= error ? f.error_message_on(:ping_at) : "What time to ping." %></span>
+    <span class='help-inline'>
+      <%= error ? f.error_message_on(:ping_at) : "Time of day to ping." %>
+    </span>
   </div>
 </fieldset>
+
+<div class="well well-sm">
+  Note: use either Interval or Ping at (<a target="_blank" href="https://github.com/tomykaira/clockwork#valid-formats">Formats</a>), not both.
+</div>
 
 
 <div class="form-actions">

--- a/config/database.rb
+++ b/config/database.rb
@@ -18,8 +18,6 @@ postgres = URI.parse(ENV['DATABASE_URL'] || '')
 ActiveRecord::Base.configurations[:development] = {
   :adapter   => 'postgresql',
   :database  => 'keepalive_development',
-  :username  => 'darron',
-  :password  => '',
   :host      => 'localhost',
   :port      => 5432
 
@@ -38,8 +36,6 @@ ActiveRecord::Base.configurations[:production] = {
 ActiveRecord::Base.configurations[:test] = {
   :adapter   => 'postgresql',
   :database  => 'keepalive_test',
-  :username  => 'root',
-  :password  => '',
   :host      => 'localhost',
   :port      => 5432
 

--- a/lib/tasks/clockwork.rake
+++ b/lib/tasks/clockwork.rake
@@ -2,21 +2,28 @@
 
 desc "Ping the urls."
 task :clockwork => :environment do
-  require 'httparty'
+  STDOUT.sync = true
+  puts "Starting keepalive"
 
-  Site.all.each do |site|
-    if site.interval?
-      Clockwork.every site.interval, site.url do
-        http = HTTParty.get(site.url)
-        logger.info "#{site.url}: #{http.response.code}"
-      end
-    elsif site.ping_at?
-      Clockwork.every 1.day, site.url, :at => site.ping_at do
-        http = HTTParty.get(site.url)
-        logger.info "#{site.url}: #{http.response.code}"
+  trap('TERM') do
+    puts "Shutting down keepalive"
+    exit
+  end
+
+  require 'clockwork'
+  require 'clockwork/manager_with_database_tasks'
+  module Clockwork
+    Clockwork.manager = ManagerWithDatabaseTasks.new
+    sync_database_tasks model: Site, every: 1.minute do |instance_job_name|
+      id = instance_job_name.split(':').first
+      begin
+        task = Site.find(id)
+        puts "Fetching url: #{task.url}"
+        task.fetch
+      rescue ActiveRecord::RecordNotFound => e
+        # site has been deleted
       end
     end
   end
-
   Clockwork.run
 end

--- a/models/site.rb
+++ b/models/site.rb
@@ -1,3 +1,28 @@
 class Site < ActiveRecord::Base
   validates_presence_of :url
+
+  # required for clockwork database_tasks
+  def at
+    ping_at
+  end
+
+  # required for clockwork database_tasks
+  def frequency
+    interval || 1.year
+  end
+
+  # required for clockwork database_tasks
+  def name
+    "#{id}: #{url}"
+  end
+
+  def fetch
+    require 'httparty'
+    begin
+      http = HTTParty.get(url)
+      logger.info "#{url}: #{http.response.code}"
+    rescue Exception => e
+      logger.info "Error fetching: #{url} #{e}"
+    end
+  end
 end


### PR DESCRIPTION
Reloads the tasks from the database. Seems to be working properly on Heroku now with `STDOUT.sync` and `trap`.
